### PR TITLE
Use AWS default VPC for Batch environment

### DIFF
--- a/deployment/src/main/terraform/main.tf
+++ b/deployment/src/main/terraform/main.tf
@@ -25,12 +25,13 @@ module s3_buckets {
 }
 
 module batch {
-  source                     = "./modules/batch"
-  heatmap_store              = data.external.secrets.result["heatmap_bucket"]
-  network_subnet_ids         = module.network.network_subnet_ids
-  network_security_group_ids = [module.network.network_security_group_id]
-  docker_registry_url        = var.DOCKER_REGISTRY_URL
-  project_version            = var.PROJECT_VERSION
+  source                      = "./modules/batch"
+  heatmap_store               = data.external.secrets.result["heatmap_bucket"]
+  network_subnet_ids          = module.network.network_subnet_ids
+  network_security_group_ids  = [module.network.network_security_group_id]
+  docker_registry_url         = var.DOCKER_REGISTRY_URL
+  project_version             = var.PROJECT_VERSION
+  data_query_access_policy_id = module.data_query.data_query_access_policy_id
 }
 
 module storage {

--- a/deployment/src/main/terraform/modules/batch/compute_environment.tf
+++ b/deployment/src/main/terraform/modules/batch/compute_environment.tf
@@ -3,16 +3,16 @@ resource aws_iam_role ecs_instance_role {
 
   assume_role_policy = <<EOF
 {
-    "Version": "2012-10-17",
-    "Statement": [
+  "Version": "2012-10-17",
+  "Statement": [
     {
-        "Action": "sts:AssumeRole",
-        "Effect": "Allow",
-        "Principal": {
+      "Action": "sts:AssumeRole",
+      "Effect": "Allow",
+      "Principal": {
         "Service": "ec2.amazonaws.com"
-        }
+      }
     }
-    ]
+  ]
 }
 EOF
 }
@@ -22,7 +22,7 @@ resource aws_iam_role_policy_attachment default_policy_attach {
   policy_arn = "arn:aws:iam::aws:policy/service-role/AmazonEC2ContainerServiceforEC2Role"
 }
 
-resource aws_iam_instance_profile ecs_instance_role {
+resource aws_iam_instance_profile ecs_instance_profile {
   name = "ecs_instance_role"
   role = aws_iam_role.ecs_instance_role.name
 }
@@ -32,67 +32,37 @@ resource aws_iam_role aws_batch_service_role {
 
   assume_role_policy = <<EOF
 {
-    "Version": "2012-10-17",
-    "Statement": [
-    {
-        "Action": "sts:AssumeRole",
-        "Effect": "Allow",
-        "Principal": {
-        "Service": "batch.amazonaws.com"
-        }
-    }
-    ]
-}
-EOF
-}
-
-resource aws_iam_policy athena_policy {
-  name = "athena_batch_policy"
-
-  policy = <<EOF
-{
   "Version": "2012-10-17",
   "Statement": [
     {
-      "Sid": "AthenaPermissions",
-       "Effect": "Allow",
-       "Action": [
-         "athena:StartQueryExecution",
-         "athena:CreateNamedQuery",
-         "athena:GetQueryResultsStream",
-         "athena:StopQueryExecution",
-         "athena:GetQueryExecution",
-         "athena:GetQueryResults",
-         "athena:BatchGetNamedQuery",
-         "athena:GetNamedQuery",
-         "athena:ListTagsForResource",
-         "athena:BatchGetQueryExecution",
-         "athena:ListQueryExecutions",
-         "athena:ListNamedQueries"
-       ],
-       "Resource": "*"
+      "Action": "sts:AssumeRole",
+      "Effect": "Allow",
+      "Principal": {
+        "Service": "batch.amazonaws.com"
+      }
     }
   ]
 }
 EOF
 }
 
-resource aws_iam_role_policy_attachment athena_policy_attach {
-  role = aws_iam_role.ecs_instance_role.name
-  policy_arn = aws_iam_policy.athena_policy.arn
-}
-
-
 resource aws_iam_role_policy_attachment aws_batch_service_role {
-  role = aws_iam_role.aws_batch_service_role.name
+  role       = aws_iam_role.aws_batch_service_role.name
   policy_arn = "arn:aws:iam::aws:policy/service-role/AWSBatchServiceRole"
 }
 
-resource aws_batch_compute_environment ukho-batch-compute-enviroment {
+resource aws_iam_role_policy_attachment data_query_policy_attachment {
+  role       = aws_iam_role.ecs_instance_role.name
+  policy_arn = var.data_query_access_policy_id
+}
+
+resource aws_batch_compute_environment batch_compute_enviroment {
   compute_environment_name = "ukho-batch-compute-enviroment"
+  type                     = "MANAGED"
 
   compute_resources {
-    instance_role = aws_iam_instance_profile.ecs_instance_role.arn
+    type          = "EC2"
+    instance_role = aws_iam_instance_profile.ecs_instance_profile.arn
 
     instance_type = [
       "optimal",
@@ -102,15 +72,9 @@ resource aws_batch_compute_environment ukho-batch-compute-enviroment {
     min_vcpus = 0
 
     security_group_ids = var.network_security_group_ids
-
-    subnets = var.network_subnet_ids
-
-    type = "EC2"
+    subnets            = var.network_subnet_ids
   }
 
   service_role = aws_iam_role.aws_batch_service_role.arn
-  type = "MANAGED"
-
-  depends_on = [
-    aws_iam_role_policy_attachment.aws_batch_service_role]
+  depends_on   = [aws_iam_role_policy_attachment.aws_batch_service_role]
 }

--- a/deployment/src/main/terraform/modules/batch/job_queue.tf
+++ b/deployment/src/main/terraform/modules/batch/job_queue.tf
@@ -2,6 +2,6 @@ resource "aws_batch_job_queue" "queue" {
   name                 = "queue"
   state                = "ENABLED"
   priority             = 1
-  compute_environments = [aws_batch_compute_environment.ukho-batch-compute-enviroment.arn]
-  depends_on           = [aws_batch_compute_environment.ukho-batch-compute-enviroment]
+  compute_environments = [aws_batch_compute_environment.batch_compute_enviroment.arn]
+  depends_on           = [aws_batch_compute_environment.batch_compute_enviroment]
 }

--- a/deployment/src/main/terraform/modules/batch/variables.tf
+++ b/deployment/src/main/terraform/modules/batch/variables.tf
@@ -3,6 +3,7 @@ variable network_subnet_ids {}
 variable network_security_group_ids {}
 variable docker_registry_url {}
 variable project_version {}
+variable data_query_access_policy_id {}
 variable step_execution_timeout_seconds {
   default = 6 * 60 * 60 * 60
 }

--- a/deployment/src/main/terraform/modules/data-query/outputs.tf
+++ b/deployment/src/main/terraform/modules/data-query/outputs.tf
@@ -1,0 +1,3 @@
+output data_query_access_policy_id {
+  value = module.data_query_perms.data_query_access_policy_id
+}

--- a/deployment/src/main/terraform/modules/data-query/permissions/data-query/main.tf
+++ b/deployment/src/main/terraform/modules/data-query/permissions/data-query/main.tf
@@ -73,7 +73,6 @@ EOF
 }
 
 resource aws_iam_group_policy_attachment data_query_access_group_permissions {
-  name = "${var.resource_prefix}Permissions"
   group = aws_iam_group.data_query_access_group.name
   policy_arn = aws_iam_policy.data_query_access_policy.arn
 }

--- a/deployment/src/main/terraform/modules/data-query/permissions/data-query/main.tf
+++ b/deployment/src/main/terraform/modules/data-query/permissions/data-query/main.tf
@@ -2,68 +2,78 @@ resource aws_iam_group data_query_access_group {
   name = "${var.resource_prefix}AccessUsers"
 }
 
-resource aws_iam_group_policy data_query_access_permissions {
-  name   = "${var.resource_prefix}Permissions"
-  group  = aws_iam_group.data_query_access_group.name
+resource aws_iam_policy data_query_access_policy {
+  name   = "${var.resource_prefix}Policy"
   policy = <<EOF
 {
-    "Version": "2012-10-17",
-    "Statement": [{
-           "Sid": "GluePermissions",
-           "Effect": "Allow",
-           "Action": [
-               "glue:GetDatabase",
-               "glue:GetPartition",
-               "glue:UpdateDatabase",
-               "glue:GetTableVersion",
-               "glue:CreateTable",
-               "glue:GetTables",
-               "glue:GetTableVersions",
-               "glue:GetPartitions",
-               "glue:UpdateTable",
-               "glue:CreatePartition",
-               "glue:GetDatabases",
-               "glue:GetTable"
-           ],
-           "Resource": "*"
-       }, {
-         "Sid": "AthenaPermissions",
-         "Effect": "Allow",
-         "Action": [
-           "athena:StartQueryExecution",
-           "athena:CreateNamedQuery",
-           "athena:GetQueryResultsStream",
-           "athena:StopQueryExecution",
-           "athena:GetQueryExecution",
-           "athena:GetQueryResults",
-           "athena:BatchGetNamedQuery",
-           "athena:GetNamedQuery",
-           "athena:ListTagsForResource",
-           "athena:BatchGetQueryExecution",
-           "athena:ListQueryExecutions",
-           "athena:ListNamedQueries"
-         ],
-         "Resource": "*"
-       }, {
-         "Sid": "S3ListPermissions",
-         "Effect": "Allow",
-         "Action": [
-            "s3:ListAllMyBuckets"
-         ],
-         "Resource": "*"
-       }, {
-         "Sid": "S3ResultsStorePermissions",
-         "Effect": "Allow",
-         "Action": [
-            "s3:PutObject*",
-            "s3:GetObject*",
-            "s3:List*"
-         ],
-         "Resource": [
-            "${var.results_store_id}",
-            "${var.results_store_id}/*"
-         ]
-       }]
+  "Version": "2012-10-17",
+  "Statement": [
+    {
+      "Sid": "GluePermissions",
+      "Effect": "Allow",
+      "Action": [
+        "glue:GetDatabase",
+        "glue:GetPartition",
+        "glue:UpdateDatabase",
+        "glue:GetTableVersion",
+        "glue:CreateTable",
+        "glue:GetTables",
+        "glue:GetTableVersions",
+        "glue:GetPartitions",
+        "glue:UpdateTable",
+        "glue:CreatePartition",
+        "glue:GetDatabases",
+        "glue:GetTable"
+      ],
+      "Resource": "*"
+    },
+    {
+      "Sid": "AthenaPermissions",
+      "Effect": "Allow",
+      "Action": [
+        "athena:StartQueryExecution",
+        "athena:CreateNamedQuery",
+        "athena:GetQueryResultsStream",
+        "athena:StopQueryExecution",
+        "athena:GetQueryExecution",
+        "athena:GetQueryResults",
+        "athena:BatchGetNamedQuery",
+        "athena:GetNamedQuery",
+        "athena:ListTagsForResource",
+        "athena:BatchGetQueryExecution",
+        "athena:ListQueryExecutions",
+        "athena:ListNamedQueries"
+      ],
+      "Resource": "*"
+    },
+    {
+      "Sid": "S3ListPermissions",
+      "Effect": "Allow",
+      "Action": [
+        "s3:ListAllMyBuckets"
+      ],
+      "Resource": "*"
+    },
+    {
+      "Sid": "S3ResultsStorePermissions",
+      "Effect": "Allow",
+      "Action": [
+        "s3:PutObject*",
+        "s3:GetObject*",
+        "s3:List*"
+      ],
+      "Resource": [
+        "${var.results_store_id}",
+        "${var.results_store_id}/*"
+      ]
+    }
+  ]
 }
 EOF
+}
+
+resource aws_iam_group_policy_attachment data_query_access_group_permissions {
+  name = "${var.resource_prefix}Permissions"
+  group = aws_iam_group.data_query_access_group.name
+  policy_arn = aws_iam_policy.data_query_access_policy.arn
 }

--- a/deployment/src/main/terraform/modules/data-query/permissions/data-query/outputs.tf
+++ b/deployment/src/main/terraform/modules/data-query/permissions/data-query/outputs.tf
@@ -1,0 +1,3 @@
+output data_query_access_policy_id {
+  value = aws_iam_policy.data_query_access_policy.arn
+}

--- a/deployment/src/main/terraform/modules/network/vpc.tf
+++ b/deployment/src/main/terraform/modules/network/vpc.tf
@@ -1,9 +1,9 @@
 module vpc {
   source = "terraform-aws-modules/vpc/aws"
 
-  name = "ukho-network"
-  cidr = "10.1.0.0/16"
+  create_vpc = false
 
-  azs             = ["eu-west-2a", "eu-west-2b", "eu-west-2c"]
-  private_subnets = ["10.1.1.0/24"]
+  manage_default_vpc               = true
+  default_vpc_name                 = "default"
+  default_vpc_enable_dns_hostnames = true
 }


### PR DESCRIPTION
* Use the AWS default VPC for creating the Batch compute environment
* Remove athena_policy, use shared policy from `data-query` module